### PR TITLE
Disable Strict Eslint Checks in the CI environment temporarily

### DIFF
--- a/upflux-client/package.json
+++ b/upflux-client/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Updated the scripts in the `package.json` to set CI=false for the build command, so warnings won't fail the build.

![image](https://github.com/user-attachments/assets/f55bad66-649f-4cec-8de8-249162548030)
