### PR TITLE
58074 - Refine UI for Engineer Dashboard

### DIFF
--- a/upflux-client/src/features/updateManagement/UpdateManagement.tsx
+++ b/upflux-client/src/features/updateManagement/UpdateManagement.tsx
@@ -30,58 +30,58 @@ export const UpdateManagement = () => {
   useSubscription(authToken);
 
     // Hardcoded machine data
-    const hardcodedMachines = [
-      {
-        machineId: "1",
-        machineName: "Machine 1",
-        ipAddress: "192.168.1.1",
-        status: "Alive",
-        applications: [
-          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
-        ]
-      },
-      {
-        machineId: "2",
-        machineName: "Machine 2",
-        ipAddress: "192.168.1.2",
-        status: "Alive",
-        applications: [
-          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
-        ]
-      },
-      {
-        machineId: "3",
-        machineName: "Machine 3",
-        ipAddress: "192.168.1.3",
-        status: "Alive",
-        applications: [
-          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
-        ]
+    // const hardcodedMachines = [
+    //   {
+    //     machineId: "c3589340-db6b-11ef-8615-2ccf677985c6",
+    //     machineName: "M01",
+    //     ipAddress: "192.168.1.1",
+    //     status: "Alive",
+    //     applications: [
+    //       { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+    //     ]
+    //   },
+    //   {
+    //     machineId: "cfb393ec-db6b-11ef-9067-2ccf677985c6",
+    //     machineName: "M02",
+    //     ipAddress: "192.168.1.2",
+    //     status: "Alive",
+    //     applications: [
+    //       { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+    //     ]
+    //   },
+    //   {
+    //     machineId: "d3b0580e-db6b-11ef-bd3e-2ccf677985c6",
+    //     machineName: "M03",
+    //     ipAddress: "192.168.1.3",
+    //     status: "Alive",
+    //     applications: [
+    //       { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+    //     ]
+    //   }
+    // ];
+
+  //Fetch accessible machines on component load
+  useEffect(() => {
+    const fetchMachines = async () => {
+      const result = await getAccessibleMachines();
+      if (typeof result === "object" && result?.accessibleMachines?.result) {
+        setMachines(result.accessibleMachines.result);
+      } else {
+        console.error("Failed to fetch machines:", result);
+        setMachines([]); // Clear machines in case of failure
       }
-    ];
+      setLoading(false);
+    };
 
-  // Fetch accessible machines on component load
-  // useEffect(() => {
-  //   const fetchMachines = async () => {
-  //     const result = await getAccessibleMachines();
-  //     if (typeof result === "object" && result?.accessibleMachines?.result) {
-  //       setMachines(result.accessibleMachines.result);
-  //     } else {
-  //       console.error("Failed to fetch machines:", result);
-  //       setMachines([]); // Clear machines in case of failure
-  //     }
-  //     setLoading(false);
-  //   };
+    const getRunningMachines = async () => {
+      await getRunningMachinesApplications().then(res => {
+        console.log(res)
+      })
+    }
 
-  //   const getRunningMachines = async () => {
-  //     await getRunningMachinesApplications().then(res => {
-  //       console.log(res)
-  //     })
-  //   }
-
-  //   getRunningMachines()
-  //   fetchMachines();
-  // }, []);
+    getRunningMachines()
+    fetchMachines();
+  }, []);
 
   // Handle Deploy Button Click
   const handleRollback = () => {
@@ -117,58 +117,51 @@ export const UpdateManagement = () => {
     }
   };
 
-    // Fetch accessible machines on component load
-    useEffect(() => {
-      setMachines(hardcodedMachines);
-      setLoading(false);
-    }, []);
-  
+  //Fetch data from the API
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:5000/api/DataRequest/engineer/engineer-applications", {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`, // Get the token from localStorage (or sessionStorage)
+          },
+        }
+        );
+        const data = await response.json();
+        setMachines(data); // Set the machines data
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    // fetchData();
+  }, []);
+
+  useEffect(() => {
+    // Fetch available applications and their versions on modal open
+    if (modalOpened) {
+      fetchPackages();
+    }
+  }, [modalOpened]);
 
   // Fetch data from the API
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const response = await fetch(
-  //         "http://localhost:5000/api/DataRequest/engineer/engineer-applications", {
-  //         method: 'GET',
-  //         headers: {
-  //           'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`, // Get the token from localStorage (or sessionStorage)
-  //         },
-  //       }
-  //       );
-  //       const data = await response.json();
-  //       setMachines(data); // Set the machines data
-  //     } catch (error) {
-  //       console.error("Error fetching data:", error);
-  //     }
-  //   };
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:5000/api/DataRequest/engineer/engineer-applications"
+        );
+        const data = await response.json();
+        setMachines(data); // Set the machines data
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
 
-  //   // fetchData();
-  // }, []);
-
-  // useEffect(() => {
-  //   // Fetch available applications and their versions on modal open
-  //   if (modalOpened) {
-  //     fetchPackages();
-  //   }
-  // }, [modalOpened]);
-
-  // // Fetch data from the API
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const response = await fetch(
-  //         "http://localhost:5000/api/DataRequest/engineer/engineer-applications"
-  //       );
-  //       const data = await response.json();
-  //       setMachines(data); // Set the machines data
-  //     } catch (error) {
-  //       console.error("Error fetching data:", error);
-  //     }
-  //   };
-
-  //   fetchData();
-  // }, []);
+    fetchData();
+  }, []);
 
   // Handle machine selection
   const handleMachineChange = (value: string | null) => {
@@ -211,12 +204,6 @@ export const UpdateManagement = () => {
   return (
 
     <Stack className="update-management-content">
-      <Box className="header">
-        <Title>
-          Engineer Dashboard
-        </Title>
-      </Box>
-
         {/* Tabs Section */}
         <Tabs defaultValue="dashboard" className="custom-tabs">
         <Tabs.List>
@@ -296,7 +283,11 @@ export const UpdateManagement = () => {
               </Table.Thead>
               <Table.Tbody>
                 {machines?.map((machine) => (
-                  <Table.Tr key={machine.machineId}>
+                  <Table.Tr
+                    key={machine.machineId}
+                    onClick={() => navigate("/version-control", { state: { machineId: machine.machineId } })}
+                    style={{ cursor: "pointer" }}
+                  >
                     <Table.Td>{machine.machineName}</Table.Td>
                     <Table.Td>{machine.machineId}</Table.Td>
                     <Table.Td>{machine.ipAddress || "N/A"}</Table.Td>

--- a/upflux-client/src/features/updateManagement/UpdateManagement.tsx
+++ b/upflux-client/src/features/updateManagement/UpdateManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Box, Button, Group, Stack, Table, Text, Badge, Modal, Select, Title } from "@mantine/core";
+import { Box, Button, Group, Stack, Table, Text, Badge, Modal, Select, Title, Tabs } from "@mantine/core";
 import { DonutChart } from "@mantine/charts";
 import { Link, useNavigate } from "react-router-dom";
 import { getAccessibleMachines } from "../../api/accessMachinesRequest";
@@ -29,28 +29,59 @@ export const UpdateManagement = () => {
 
   useSubscription(authToken);
 
-  // Fetch accessible machines on component load
-  useEffect(() => {
-    const fetchMachines = async () => {
-      const result = await getAccessibleMachines();
-      if (typeof result === "object" && result?.accessibleMachines?.result) {
-        setMachines(result.accessibleMachines.result);
-      } else {
-        console.error("Failed to fetch machines:", result);
-        setMachines([]); // Clear machines in case of failure
+    // Hardcoded machine data
+    const hardcodedMachines = [
+      {
+        machineId: "1",
+        machineName: "Machine 1",
+        ipAddress: "192.168.1.1",
+        status: "Alive",
+        applications: [
+          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+        ]
+      },
+      {
+        machineId: "2",
+        machineName: "Machine 2",
+        ipAddress: "192.168.1.2",
+        status: "Alive",
+        applications: [
+          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+        ]
+      },
+      {
+        machineId: "3",
+        machineName: "Machine 3",
+        ipAddress: "192.168.1.3",
+        status: "Alive",
+        applications: [
+          { name: "UpFlux-Monitoring-Service", versions: ["1.0.0", "1.1.0"] }
+        ]
       }
-      setLoading(false);
-    };
+    ];
 
-    const getRunningMachines = async () => {
-      await getRunningMachinesApplications().then(res => {
-        console.log(res)
-      })
-    }
+  // Fetch accessible machines on component load
+  // useEffect(() => {
+  //   const fetchMachines = async () => {
+  //     const result = await getAccessibleMachines();
+  //     if (typeof result === "object" && result?.accessibleMachines?.result) {
+  //       setMachines(result.accessibleMachines.result);
+  //     } else {
+  //       console.error("Failed to fetch machines:", result);
+  //       setMachines([]); // Clear machines in case of failure
+  //     }
+  //     setLoading(false);
+  //   };
 
-    getRunningMachines()
-    fetchMachines();
-  }, []);
+  //   const getRunningMachines = async () => {
+  //     await getRunningMachinesApplications().then(res => {
+  //       console.log(res)
+  //     })
+  //   }
+
+  //   getRunningMachines()
+  //   fetchMachines();
+  // }, []);
 
   // Handle Deploy Button Click
   const handleRollback = () => {
@@ -86,51 +117,58 @@ export const UpdateManagement = () => {
     }
   };
 
-  // Fetch data from the API
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(
-          "http://localhost:5000/api/DataRequest/engineer/engineer-applications", {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`, // Get the token from localStorage (or sessionStorage)
-          },
-        }
-        );
-        const data = await response.json();
-        setMachines(data); // Set the machines data
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      }
-    };
-
-    // fetchData();
-  }, []);
-
-  useEffect(() => {
-    // Fetch available applications and their versions on modal open
-    if (modalOpened) {
-      fetchPackages();
-    }
-  }, [modalOpened]);
+    // Fetch accessible machines on component load
+    useEffect(() => {
+      setMachines(hardcodedMachines);
+      setLoading(false);
+    }, []);
+  
 
   // Fetch data from the API
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch(
-          "http://localhost:5000/api/DataRequest/engineer/engineer-applications"
-        );
-        const data = await response.json();
-        setMachines(data); // Set the machines data
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      }
-    };
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     try {
+  //       const response = await fetch(
+  //         "http://localhost:5000/api/DataRequest/engineer/engineer-applications", {
+  //         method: 'GET',
+  //         headers: {
+  //           'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`, // Get the token from localStorage (or sessionStorage)
+  //         },
+  //       }
+  //       );
+  //       const data = await response.json();
+  //       setMachines(data); // Set the machines data
+  //     } catch (error) {
+  //       console.error("Error fetching data:", error);
+  //     }
+  //   };
 
-    fetchData();
-  }, []);
+  //   // fetchData();
+  // }, []);
+
+  // useEffect(() => {
+  //   // Fetch available applications and their versions on modal open
+  //   if (modalOpened) {
+  //     fetchPackages();
+  //   }
+  // }, [modalOpened]);
+
+  // // Fetch data from the API
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     try {
+  //       const response = await fetch(
+  //         "http://localhost:5000/api/DataRequest/engineer/engineer-applications"
+  //       );
+  //       const data = await response.json();
+  //       setMachines(data); // Set the machines data
+  //     } catch (error) {
+  //       console.error("Error fetching data:", error);
+  //     }
+  //   };
+
+  //   fetchData();
+  // }, []);
 
   // Handle machine selection
   const handleMachineChange = (value: string | null) => {
@@ -179,12 +217,24 @@ export const UpdateManagement = () => {
         </Title>
       </Box>
 
+        {/* Tabs Section */}
+        <Tabs defaultValue="dashboard" className="custom-tabs">
+        <Tabs.List>
+          <Tabs.Tab value="dashboard" className="custom-tab">
+            Dashboard
+          </Tabs.Tab>
+          <Tabs.Tab value="applications" className="custom-tab" onClick={() => navigate("/version-control")}>
+            Applications
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
+
       <Box className="content-wrapper">
         <Group className="overview-section">
           <Box className="chart">
-            <DonutChart className="chart" withTooltip={false} data={chartData} />
+            <DonutChart className="chart" size={180} thickness={14} withTooltip={false} data={chartData} />
             <Text className="chart-text">
-              <br />  Machines <br /> {machines.length}
+              <br /> QC Machines <br /> {machines.length}
             </Text>
           </Box>
 

--- a/upflux-client/src/features/updateManagement/UpdateManagement.tsx
+++ b/upflux-client/src/features/updateManagement/UpdateManagement.tsx
@@ -288,10 +288,10 @@ export const UpdateManagement = () => {
                   <Table.Th>Machine Name</Table.Th>
                   <Table.Th>Machine ID</Table.Th>
                   <Table.Th>IP Address</Table.Th>
+                  <Table.Th>Current Version</Table.Th>
                   <Table.Th>Last Update</Table.Th>
                   <Table.Th>Updated By</Table.Th>
                   <Table.Th>Current Status</Table.Th>
-                  <Table.Th>View</Table.Th>
                 </Table.Tr>
               </Table.Thead>
               <Table.Tbody>
@@ -300,18 +300,11 @@ export const UpdateManagement = () => {
                     <Table.Td>{machine.machineName}</Table.Td>
                     <Table.Td>{machine.machineId}</Table.Td>
                     <Table.Td>{machine.ipAddress || "N/A"}</Table.Td>
+                    <Table.Td>{machine.applications[0].versions[0]}</Table.Td>
                     <Table.Td>{"02/08/2024"}</Table.Td>
                     <Table.Td>{"John Doe"}</Table.Td>
                     <Table.Td>
                       <Badge color="green">{machine.status || "Alive"}</Badge>
-                    </Table.Td>
-                    <Table.Td>
-                      <Link
-                        to="/version-control"
-                        state={{ machineId: machine.machineId }}
-                      >
-                        <img src={view} alt="view" className="view" />
-                      </Link>
                     </Table.Td>
                   </Table.Tr>
                 ))}

--- a/upflux-client/src/features/updateManagement/update-management.css
+++ b/upflux-client/src/features/updateManagement/update-management.css
@@ -105,8 +105,8 @@
 }
 
 .machine-table th,
-td {
-  padding: 10px;
+.machine-table td {
+  padding: 15px;
   text-align: left;
   border-bottom: 1px solid #ddd;
 }
@@ -142,16 +142,16 @@ margin-left: 1px;
 .custom-tab {
   background-color: white;
   border: 1px solid black;
-  border-radius: 8px 8px 0 0; /* Rounded corners at the top */
-  margin-right: 8px; /* Space between tabs */
+  border-radius: 8px 8px 0 0; 
+  margin-right: 8px; 
   padding: 10px 20px;
   font-weight: bold;
   cursor: pointer;
 }
 
 .custom-tab[data-active] {
-  border-bottom: none; /* Remove bottom border for active tab */
-  background-color: #f0f0f0; /* Slight gray background for active tab */
+  border-bottom: none; 
+  background-color: #f0f0f0; 
 }
 
 @media (max-width: 768px) {

--- a/upflux-client/src/features/updateManagement/update-management.css
+++ b/upflux-client/src/features/updateManagement/update-management.css
@@ -9,11 +9,11 @@
 /* Content Wrapper */
 .content-wrapper {
   border: 1px solid #ddd;
-  border-radius: 10px;
+  border-radius: 5px;
   padding: 20px;
   background-color: #fff;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-  margin-top: 20px;
+  margin-top: -18px;
 }
 
 /* Header */
@@ -133,6 +133,25 @@ td {
   text-align: center;
   font-size: 23px;
   font-weight: bold;
+}
+
+.custom-tabs {
+margin-left: 1px;
+}
+
+.custom-tab {
+  background-color: white;
+  border: 1px solid black;
+  border-radius: 8px 8px 0 0; /* Rounded corners at the top */
+  margin-right: 8px; /* Space between tabs */
+  padding: 10px 20px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.custom-tab[data-active] {
+  border-bottom: none; /* Remove bottom border for active tab */
+  background-color: #f0f0f0; /* Slight gray background for active tab */
 }
 
 @media (max-width: 768px) {

--- a/upflux-client/src/features/versionControl/VersionControl.tsx
+++ b/upflux-client/src/features/versionControl/VersionControl.tsx
@@ -10,7 +10,9 @@ import {
   Modal,
   RingProgress,
   SimpleGrid,
+  Tabs
 } from "@mantine/core";
+import { Link, useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import "./versionControl.css";
 import { getMachineDetails } from "../../api/applicationsRequest";
@@ -19,21 +21,53 @@ import { RootState } from "../reduxSubscription/store";
 import { IApplications } from "../reduxSubscription/applicationVersions";
 
 export const VersionControl: React.FC = () => {
-  // State for Modal visibility
-  const [modalOpened, setModalOpened] = useState(false);
-  const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages)
-  const machineMetrics = useSelector(
-    (state: RootState) => state.metrics.metrics
-  );
-  // Retrieve machine ID from the route state
+  const navigate = useNavigate();
+
+    // Hardcoded machine metrics data
+    const machineMetrics = {
+      "1": {
+        metrics: {
+          cpuUsage: 45,
+          cpuTemperature: 60,
+          memoryUsage: 70,
+          diskUsage: 30,
+          systemUptime: 123456, // Uptime in seconds
+        },
+      },
+    };
+  
+    // Hardcoded applications data
+    const applications = {
+      "1": {
+        VersionNames: ["1.0.0", "1.1.0", "1.2.0"],
+      },
+    };
+  
+    // Hardcoded app versions data
+    const appVersions = [
+      {
+        appName: "UpFlux-Monitoring-Service",
+        appVersion: "1.0.0",
+        lastUpdate: "Jan 10 2024",
+      },
+      {
+        appName: "UpFlux-Monitoring-Service",
+        appVersion: "1.1.0",
+        lastUpdate: "Feb 15 2024",
+      },
+      {
+        appName: "UpFlux-Monitoring-Service",
+        appVersion: "1.2.0",
+        lastUpdate: "Mar 20 2024",
+      },
+    ];
+
+      // Retrieve machine ID from the route state
   const location = useLocation();
-  const machineId = location.state?.machineId || "Unknown Machine";
+  const machineId = location.state?.machineId || "1"; // Default to "1" for hardcoded data
 
   // State for app versions and loading status
-  const [appVersions, setAppVersions] = useState<
-    { appName: string; appVersion: string; lastUpdate: string }[]
-  >([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   const formatUptime = (seconds: number): string => {
     const days = Math.floor(seconds / (24 * 3600));
@@ -42,6 +76,30 @@ export const VersionControl: React.FC = () => {
 
     return `${days}d ${hours}h ${minutes}m`;
   };
+
+  // State for Modal visibility
+  const [modalOpened, setModalOpened] = useState(false);
+  // const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages)
+  // const machineMetrics = useSelector(
+  //   (state: RootState) => state.metrics.metrics
+  // );
+  // // Retrieve machine ID from the route state
+  // const location = useLocation();
+  // const machineId = location.state?.machineId || "Unknown Machine";
+
+  // // State for app versions and loading status
+  // const [appVersions, setAppVersions] = useState<
+  //   { appName: string; appVersion: string; lastUpdate: string }[]
+  // >([]);
+  // const [isLoading, setIsLoading] = useState(true);
+
+  // const formatUptime = (seconds: number): string => {
+  //   const days = Math.floor(seconds / (24 * 3600));
+  //   const hours = Math.floor((seconds % (24 * 3600)) / 3600);
+  //   const minutes = Math.floor((seconds % 3600) / 60);
+
+  //   return `${days}d ${hours}h ${minutes}m`;
+  // };
 
 
   // Mocked machine metrics data
@@ -73,34 +131,34 @@ export const VersionControl: React.FC = () => {
     return "red";
   };
 
-  // Fetch data from API
-  useEffect(() => {
-    const fetchMachineDetails = async () => {
-      try {
-        const data = await getMachineDetails();
-        if (data && typeof data !== "string" && data.applications) {
-          // Filter applications for the current machineId
-          const filteredApps = data.applications
-            .filter((app) => app.machineId === machineId)
-            .map((app) => ({
-              appName: app.appName,
-              appVersion: app.currentVersion,
-              lastUpdate: app.versions?.[0]?.date || "N/A",
-            }));
+  // // Fetch data from API
+  // useEffect(() => {
+  //   const fetchMachineDetails = async () => {
+  //     try {
+  //       const data = await getMachineDetails();
+  //       if (data && typeof data !== "string" && data.applications) {
+  //         // Filter applications for the current machineId
+  //         const filteredApps = data.applications
+  //           .filter((app) => app.machineId === machineId)
+  //           .map((app) => ({
+  //             appName: app.appName,
+  //             appVersion: app.currentVersion,
+  //             lastUpdate: app.versions?.[0]?.date || "N/A",
+  //           }));
 
-          setAppVersions(filteredApps);
-        } else {
-          console.error("Failed to fetch or parse machine details.");
-        }
-      } catch (error) {
-        console.error("Error fetching machine details:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  //         setAppVersions(filteredApps);
+  //       } else {
+  //         console.error("Failed to fetch or parse machine details.");
+  //       }
+  //     } catch (error) {
+  //       console.error("Error fetching machine details:", error);
+  //     } finally {
+  //       setIsLoading(false);
+  //     }
+  //   };
 
-    fetchMachineDetails();
-  }, [machineId]);
+  //   fetchMachineDetails();
+  // }, [machineId]);
 
   return (
     <Stack className="version-control-content">
@@ -110,6 +168,18 @@ export const VersionControl: React.FC = () => {
           Version Control
         </Text>
       </Box>
+
+              {/* Tabs Section */}
+              <Tabs defaultValue="applications" className="custom-tabs">
+              <Tabs.List>
+                <Tabs.Tab value="dashboard" className="custom-tab" onClick={() => navigate("/update-management")}>
+                  Dashboard
+                </Tabs.Tab>
+                <Tabs.Tab value="applications" className="custom-tab">
+                  Applications
+                </Tabs.Tab>
+              </Tabs.List>
+            </Tabs>
 
       <Box className="content-wrapper">
         <Box className="machine-id-box">

--- a/upflux-client/src/features/versionControl/VersionControl.tsx
+++ b/upflux-client/src/features/versionControl/VersionControl.tsx
@@ -24,50 +24,59 @@ export const VersionControl: React.FC = () => {
   const navigate = useNavigate();
 
     // Hardcoded machine metrics data
-    const machineMetrics = {
-      "1": {
-        metrics: {
-          cpuUsage: 45,
-          cpuTemperature: 60,
-          memoryUsage: 70,
-          diskUsage: 30,
-          systemUptime: 123456, // Uptime in seconds
-        },
-      },
-    };
+    // const machineMetrics = {
+    //   "M01": {
+    //     metrics: {
+    //       cpuUsage: 45,
+    //       cpuTemperature: 60,
+    //       memoryUsage: 70,
+    //       diskUsage: 30,
+    //       systemUptime: 123456, // Uptime in seconds
+    //     },
+    //   },
+    // };
   
-    // Hardcoded applications data
-    const applications = {
-      "1": {
-        VersionNames: ["1.0.0", "1.1.0", "1.2.0"],
-      },
-    };
+    // // Hardcoded applications data
+    // const applications = {
+    //   "M01": {
+    //     VersionNames: ["1.0.0", "1.1.0", "1.2.0"],
+    //   },
+    // };
   
-    // Hardcoded app versions data
-    const appVersions = [
-      {
-        appName: "UpFlux-Monitoring-Service",
-        appVersion: "1.0.0",
-        lastUpdate: "Jan 10 2024",
-      },
-      {
-        appName: "UpFlux-Monitoring-Service",
-        appVersion: "1.1.0",
-        lastUpdate: "Feb 15 2024",
-      },
-      {
-        appName: "UpFlux-Monitoring-Service",
-        appVersion: "1.2.0",
-        lastUpdate: "Mar 20 2024",
-      },
-    ];
+    // // Hardcoded app versions data
+    // const appVersions = [
+    //   {
+    //     appName: "UpFlux-Monitoring-Service",
+    //     appVersion: "1.0.0",
+    //     lastUpdate: "Jan 10 2024",
+    //   },
+    //   {
+    //     appName: "UpFlux-Monitoring-Service",
+    //     appVersion: "1.1.0",
+    //     lastUpdate: "Feb 15 2024",
+    //   },
+    //   {
+    //     appName: "UpFlux-Monitoring-Service",
+    //     appVersion: "1.2.0",
+    //     lastUpdate: "Mar 20 2024",
+    //   },
+    // ];
 
-      // Retrieve machine ID from the route state
+  // State for Modal visibility
+  const [modalOpened, setModalOpened] = useState(false);
+  const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages)
+  const machineMetrics = useSelector(
+    (state: RootState) => state.metrics.metrics
+  );
+  // Retrieve machine ID from the route state
   const location = useLocation();
-  const machineId = location.state?.machineId || "1"; // Default to "1" for hardcoded data
+  const machineId = location.state?.machineId || "Unknown Machine";
 
   // State for app versions and loading status
-  const [isLoading, setIsLoading] = useState(false);
+  const [appVersions, setAppVersions] = useState<
+    { appName: string; appVersion: string; lastUpdate: string }[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const formatUptime = (seconds: number): string => {
     const days = Math.floor(seconds / (24 * 3600));
@@ -76,31 +85,6 @@ export const VersionControl: React.FC = () => {
 
     return `${days}d ${hours}h ${minutes}m`;
   };
-
-  // State for Modal visibility
-  const [modalOpened, setModalOpened] = useState(false);
-  // const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages)
-  // const machineMetrics = useSelector(
-  //   (state: RootState) => state.metrics.metrics
-  // );
-  // // Retrieve machine ID from the route state
-  // const location = useLocation();
-  // const machineId = location.state?.machineId || "Unknown Machine";
-
-  // // State for app versions and loading status
-  // const [appVersions, setAppVersions] = useState<
-  //   { appName: string; appVersion: string; lastUpdate: string }[]
-  // >([]);
-  // const [isLoading, setIsLoading] = useState(true);
-
-  // const formatUptime = (seconds: number): string => {
-  //   const days = Math.floor(seconds / (24 * 3600));
-  //   const hours = Math.floor((seconds % (24 * 3600)) / 3600);
-  //   const minutes = Math.floor((seconds % 3600) / 60);
-
-  //   return `${days}d ${hours}h ${minutes}m`;
-  // };
-
 
   // Mocked machine metrics data
   const metrics = [
@@ -131,43 +115,38 @@ export const VersionControl: React.FC = () => {
     return "red";
   };
 
-  // // Fetch data from API
-  // useEffect(() => {
-  //   const fetchMachineDetails = async () => {
-  //     try {
-  //       const data = await getMachineDetails();
-  //       if (data && typeof data !== "string" && data.applications) {
-  //         // Filter applications for the current machineId
-  //         const filteredApps = data.applications
-  //           .filter((app) => app.machineId === machineId)
-  //           .map((app) => ({
-  //             appName: app.appName,
-  //             appVersion: app.currentVersion,
-  //             lastUpdate: app.versions?.[0]?.date || "N/A",
-  //           }));
+  // Fetch data from API
+  useEffect(() => {
+    const fetchMachineDetails = async () => {
+      try {
+        const data = await getMachineDetails();
+        if (data && typeof data !== "string" && data.applications) {
+          // Filter applications for the current machineId
+          const filteredApps = data.applications
+            .filter((app) => app.machineId === machineId)
+            .map((app) => ({
+              appName: app.appName,
+              appVersion: app.currentVersion,
+              lastUpdate: app.versions?.[0]?.date || "N/A",
+            }));
 
-  //         setAppVersions(filteredApps);
-  //       } else {
-  //         console.error("Failed to fetch or parse machine details.");
-  //       }
-  //     } catch (error) {
-  //       console.error("Error fetching machine details:", error);
-  //     } finally {
-  //       setIsLoading(false);
-  //     }
-  //   };
+          setAppVersions(filteredApps);
+        } else {
+          console.error("Failed to fetch or parse machine details.");
+        }
+      } catch (error) {
+        console.error("Error fetching machine details:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-  //   fetchMachineDetails();
-  // }, [machineId]);
+    fetchMachineDetails();
+  }, [machineId]);
 
   return (
     <Stack className="version-control-content">
       {/* Header */}
-      <Box className="header">
-        <Text size="xl" fw={700}>
-          Version Control
-        </Text>
-      </Box>
 
               {/* Tabs Section */}
               <Tabs defaultValue="applications" className="custom-tabs">
@@ -182,10 +161,15 @@ export const VersionControl: React.FC = () => {
             </Tabs>
 
       <Box className="content-wrapper">
-        <Box className="machine-id-box">
-          {/* Display the machine ID */}
-          <Text>{`Machine ${machineId}`}</Text>
-        </Box>
+      <Box className="machine-id-box">
+        <Select
+          data={Object.keys(machineMetrics)} 
+          value={machineId}
+          onChange={(value) => navigate(".", { state: { machineId: value } })}
+          placeholder="Select Machine"
+        />
+      </Box>
+
 
         {/* Overview Section */}
         <Group className="overview-section">

--- a/upflux-client/src/features/versionControl/versionControl.css
+++ b/upflux-client/src/features/versionControl/versionControl.css
@@ -7,14 +7,12 @@
   
   .machine-id-box {
     display: inline-block;
-    background-color: #f9f9f9;
-    padding: 10px 20px;
     border: 1px solid #ccc;
-    border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     font-size: 16px;
     font-weight: 600;
-    margin-top: 40px;
+    margin-top: 15px;
+    margin-bottom: 15px;
   }
 
   .version-table {
@@ -49,10 +47,10 @@
   }
 
   .version-control-content {
-    flex: 1; /* Allows this component to take up available space */
-    display: flex;
-    flex-direction: column;
-    min-height: 70vh;
+    max-width: 1400px;
+    margin: auto;
+    padding: 20px;
+    min-height: 75vh;
   }
 
   .metrics-container{


### PR DESCRIPTION
Done in this branch:

- Implemented tabs for better navigation between engineer pages
- Updated machine data fields in table
- Minor styling & spacing improvements for engineer dashboard elements
- Added a Select dropdown for switching between machines in applications page
- Minor styling and spacing improvements for applications page elements

Screenshots:

Engineer Dashboard:
![dashboard](https://github.com/user-attachments/assets/fb791406-ac95-465f-8337-bb82f27b9176)

Applications Page:
![versionnn](https://github.com/user-attachments/assets/da570566-d038-4dd2-aefc-2565265c8fb9)
