### PR TITLE
Control Channel Package Signature Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ packages/
 /Upflux-GatewaySimulator/Upflux-GatewaySimulator/Available
 /Upflux-GatewaySimulator/Upflux-GatewaySimulator/Current
 /Upflux-GatewaySimulator/Upflux-GatewaySimulator/ScheduledUpdates
+/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Signature
+/Upflux-GatewaySimulator/Upflux-GatewaySimulator/ScheduledUpdateSignature

--- a/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Program.cs
+++ b/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Program.cs
@@ -589,16 +589,21 @@ async Task HandleUpdatePackage(UpdatePackage updatePackage)
 		Console.WriteLine(
 			$"Received UpdatePackage: FileName={updatePackage.FileName}, Size={updatePackage.PackageData.Length} bytes");
 
+		Console.WriteLine(
+			$"Received Signature: Size={updatePackage.SignatureData.Length} bytes");
+
 		// Traverse to the root directory of the project
 		var rootDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../.."));
 
 		// Define directories
 		var currentDirectory = Path.Combine(rootDirectory, "Current");
 		var availableDirectory = Path.Combine(rootDirectory, "Available");
+		var signatureDirectory = Path.Combine(rootDirectory, "Signature");
 
 		// Ensure directories exist
 		Directory.CreateDirectory(currentDirectory);
 		Directory.CreateDirectory(availableDirectory);
+		Directory.CreateDirectory(signatureDirectory);
 
 		// Get any existing file in "Current" (since only one should exist)
 		var existingFiles = Directory.GetFiles(currentDirectory);
@@ -628,6 +633,10 @@ async Task HandleUpdatePackage(UpdatePackage updatePackage)
 		var newFilePath = Path.Combine(currentDirectory, updatePackage.FileName);
 		await File.WriteAllBytesAsync(newFilePath, updatePackage.PackageData.ToByteArray());
 		Console.WriteLine($"UpdatePackage saved to: {newFilePath}");
+
+		var signatureFilePath = Path.Combine(signatureDirectory, updatePackage.FileName + ".sig");
+		await File.WriteAllBytesAsync(signatureFilePath, updatePackage.SignatureData.ToByteArray());
+		Console.WriteLine($"Signature saved to: {signatureFilePath}");
 
 		// Simulate success/failure for target devices
 		List<string> succeededDevices = new List<string>();
@@ -774,13 +783,19 @@ async Task HandleScheduledUpdate(ScheduledUpdate scheduledUpdate)
 
 		// Define the directory for scheduled updates
 		var scheduledUpdateDirectory = Path.Combine(rootDirectory, "ScheduledUpdates");
+		var scheduledUpdateSignatureDirectory = Path.Combine(rootDirectory, "ScheduledUpdateSignature");
 
 		// Ensure the directory exists
 		Directory.CreateDirectory(scheduledUpdateDirectory);
+		Directory.CreateDirectory(scheduledUpdateSignatureDirectory);
 
 		// Save package data to disk
 		string savePath = Path.Combine(scheduledUpdateDirectory, scheduledUpdate.FileName);
 		await File.WriteAllBytesAsync(savePath, scheduledUpdate.PackageData.ToByteArray());
+
+		// save signature
+		string saveSignaturePath = Path.Combine(scheduledUpdateSignatureDirectory, scheduledUpdate.FileName + ".sig");
+		await File.WriteAllBytesAsync(saveSignaturePath, scheduledUpdate.SignatureData.ToByteArray());
 
 		Console.WriteLine($"✅ Package saved at {savePath}");
 

--- a/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Protos/controlchannel.proto
+++ b/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Protos/controlchannel.proto
@@ -146,7 +146,8 @@ message SensorData {
 message UpdatePackage {
   string fileName = 1;           // .deb package name
   bytes packageData = 2;         // The raw .deb 
-  repeated string targetDevices = 3;
+  bytes signatureData = 3;      // The signature of the .deb
+  repeated string targetDevices = 4;
 }
 
 message UpdateAck {
@@ -217,7 +218,8 @@ message ScheduledUpdate {
   string clusterId = 3;          
   string fileName = 4;           
   bytes packageData = 5;        
-  google.protobuf.Timestamp startTime = 6; 
+  bytes signatureData = 6;
+  google.protobuf.Timestamp startTime = 7; 
 }
 
 // ====================== DEVICE STATUS =====================

--- a/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Upflux-GatewaySimulator.csproj
+++ b/Upflux-GatewaySimulator/Upflux-GatewaySimulator/Upflux-GatewaySimulator.csproj
@@ -30,6 +30,7 @@
         <Folder Include="Current\" />
         <Folder Include="Available\" />
         <Folder Include="ScheduledUpdates\" />
+        <Folder Include="Signature\" />
     </ItemGroup>
 
 </Project>

--- a/upflux-webservice/Upflux-WebService/Controllers/PackageManagementController.cs
+++ b/upflux-webservice/Upflux-WebService/Controllers/PackageManagementController.cs
@@ -220,14 +220,31 @@ public class PackageManagementController : ControllerBase
 		var packageFile = Directory.GetFiles(packageDirectory)
 			.FirstOrDefault(f => f.Contains(request.Version) && f.EndsWith(".deb"));
 
+		// Look for a .sig file matching the package version
+		var signatureFile = Directory.GetFiles(packageDirectory)
+			.FirstOrDefault(f => f.Contains(request.Version) && f.EndsWith(".sig"));
+
 		if (packageFile == null)
 			return NotFound("Matching .deb package version not found.");
+
+		if (signatureFile == null)
+			return NotFound("Matching .sig version signature not found.");
 
 		try
 		{
 			var packageData = await System.IO.File.ReadAllBytesAsync(packageFile);
-			await _controlChannelService.SendUpdatePackageAsync(_gatewayId, Path.GetFileName(packageFile), packageData,
-				request.TargetDevices, request.Name, request.Version, engineerEmail);
+			var signatureData = await System.IO.File.ReadAllBytesAsync(signatureFile);
+
+			await _controlChannelService.SendUpdatePackageAsync(
+				_gatewayId, 
+				Path.GetFileName(packageFile),
+				packageData, 
+				signatureData,
+				request.TargetDevices, 
+				request.Name, 
+				request.Version, 
+				engineerEmail
+			);
 
 			return Ok($"Package [{request.Name}] version [{request.Version}] uploaded successfully.");
 		}
@@ -238,6 +255,11 @@ public class PackageManagementController : ControllerBase
 		}
 	}
 
+	/// <summary>
+	/// upload scheduled package to gateway
+	/// </summary>
+	/// <param name="request"></param>
+	/// <returns></returns>
 	[HttpPost("packages/schedule-update")]
 	[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme, Roles = "Engineer")]
 	public async Task<IActionResult> UploadScheduledPackageToGateway([FromBody] ScheduledUpdateRequest request)
@@ -259,14 +281,31 @@ public class PackageManagementController : ControllerBase
 		var packageFile = Directory.GetFiles(packageDirectory)
 			.FirstOrDefault(f => f.Contains(request.Version) && f.EndsWith(".deb"));
 
+		// Look for a .sig file matching the package version
+		var signatureFile = Directory.GetFiles(packageDirectory)
+			.FirstOrDefault(f => f.Contains(request.Version) && f.EndsWith(".sig"));
+
 		if (packageFile == null)
 			return NotFound("Matching .deb package version not found.");
+
+		if (signatureFile == null)
+			return NotFound("Matching .sig version signature not found.");
 
 		try
 		{
 			var packageData = await System.IO.File.ReadAllBytesAsync(packageFile);
+			var signatureData = await System.IO.File.ReadAllBytesAsync(signatureFile);
 			string scheduleId = Guid.NewGuid().ToString("N");
-			await _controlChannelService.SendScheduledUpdateAsync(_gatewayId, scheduleId, request.TargetDevices, Path.GetFileName(packageFile), packageData, request.startTimeUtc,engineerEmail);
+
+			await _controlChannelService.SendScheduledUpdateAsync(
+				_gatewayId, 
+				scheduleId, 
+				request.TargetDevices, 
+				Path.GetFileName(packageFile), 
+				packageData, signatureData, 
+				request.startTimeUtc, 
+				engineerEmail
+			);
 
 			return Ok($"Package [{request.Name}] version [{request.Version}] uploaded successfully.");
 		}

--- a/upflux-webservice/Upflux-WebService/Protos/controlchannel.proto
+++ b/upflux-webservice/Upflux-WebService/Protos/controlchannel.proto
@@ -72,24 +72,6 @@ message LicenseResponse {
   google.protobuf.Timestamp expirationDate = 4;
 }
 
-message AddUnregisteredDeviceRequest {
-	string deviceUuid = 1;
-}
-
-message AddUnregisteredDeviceResponse {
-	bool isSuccesful = 1;
-	string message = 2;
-}
-
-message LicenceValidationRequest {
-	string licenseContent = 1;
-}
-
-message LicenceValidationResponse {
-	bool isValid = 1;
-	string message = 2;
-}
-
 // ==================== COMMANDS ====================
 message CommandRequest {
   string commandId = 1;
@@ -164,7 +146,8 @@ message SensorData {
 message UpdatePackage {
   string fileName = 1;           // .deb package name
   bytes packageData = 2;         // The raw .deb 
-  repeated string targetDevices = 3;
+  bytes signatureData = 3;      // The signature of the .deb
+  repeated string targetDevices = 4;
 }
 
 message UpdateAck {
@@ -235,7 +218,8 @@ message ScheduledUpdate {
   string clusterId = 3;          
   string fileName = 4;           
   bytes packageData = 5;        
-  google.protobuf.Timestamp startTime = 6; 
+  bytes signatureData = 6;
+  google.protobuf.Timestamp startTime = 7; 
 }
 
 // ====================== DEVICE STATUS =====================

--- a/upflux-webservice/Upflux-WebService/Services/ControlChannelService.cs
+++ b/upflux-webservice/Upflux-WebService/Services/ControlChannelService.cs
@@ -972,6 +972,7 @@ namespace UpFlux_WebService
 			string gatewayId,
 			string fileName,
 			byte[] packageData,
+			byte[] signatureData,
 			string[] targetDevices,
 			string appName,
 			string version,
@@ -996,14 +997,15 @@ namespace UpFlux_WebService
 			var update = new UpdatePackage
 			{
 				FileName = fileName,
-				PackageData = Google.Protobuf.ByteString.CopyFrom(packageData)
+				PackageData = Google.Protobuf.ByteString.CopyFrom(packageData),
+				SignatureData = Google.Protobuf.ByteString.CopyFrom(signatureData)
 			};
 			update.TargetDevices.AddRange(targetDevices);
 
 			var msg = new ControlMessage
 			{
 				SenderId = "Cloud",
-				UpdatePackage = update
+				UpdatePackage = update,
 			};
 
 			_updateMetadataMap[fileName] = new UpdateMetadata
@@ -1058,7 +1060,9 @@ namespace UpFlux_WebService
 		/// <param name="deviceUuids">The devices to target</param>
 		/// <param name="fileName">The name of the update package</param>
 		/// <param name="packageData">The binary data of the update package</param>
+		/// <param name="signatureData">The binary data of the signature file</param>
 		/// <param name="startTimeUtc">The start time for the update</param>
+		/// <param name="userEmail">the user who initiated the scheduledUpdate</param>
 		/// <returns>Returns the task for the async operation</returns>
 		public async Task SendScheduledUpdateAsync(
 			string gatewayId,
@@ -1066,6 +1070,7 @@ namespace UpFlux_WebService
 			string[] deviceUuids,
 			string fileName,
 			byte[] packageData,
+			byte[] signatureData,
 			DateTime startTimeUtc,
 			string userEmail
 		)
@@ -1092,11 +1097,12 @@ namespace UpFlux_WebService
 				ScheduleId = scheduleId,
 				FileName = fileName,
 				PackageData = Google.Protobuf.ByteString.CopyFrom(packageData),
+				SignatureData = Google.Protobuf.ByteString.CopyFrom(signatureData),
 				StartTime = Timestamp.FromDateTime(startTimeUtc.ToUniversalTime())
 			};
 			su.DeviceUuids.AddRange(deviceUuids);
 
-			ControlMessage msg = new ControlMessage
+			ControlMessage msg = new()
 			{
 				SenderId = "Cloud",
 				ScheduledUpdate = su

--- a/upflux-webservice/Upflux-WebService/Services/Interfaces/IControlChannelService.cs
+++ b/upflux-webservice/Upflux-WebService/Services/Interfaces/IControlChannelService.cs
@@ -43,10 +43,13 @@ namespace Upflux_WebService.Services.Interfaces
 		/// <param name="gatewayId"></param>
 		/// <param name="fileName"></param>
 		/// <param name="packageData"></param>
+		/// <param name="signatureData"></param>
 		/// <param name="targetDevices"></param>
 		/// <param name="appName"></param>
+		/// <param name="version"></param>
+		/// <param name="userEmail"></param>
 		/// <returns></returns>
-		Task SendUpdatePackageAsync(string gatewayId, string fileName, byte[] packageData, string[] targetDevices, string appName, string version, string userEmail);
+		Task SendUpdatePackageAsync(string gatewayId, string fileName, byte[] packageData, byte[] signatureData, string[] targetDevices, string appName, string version, string userEmail);
 
 		/// <summary>
 		/// 
@@ -63,6 +66,7 @@ namespace Upflux_WebService.Services.Interfaces
 		/// <param name="deviceUuids"></param>
 		/// <param name="fileName"></param>
 		/// <param name="packageData"></param>
+		/// <param name="signatureData"></param>
 		/// <param name="startTimeUtc"></param>
 		/// <param name="userEmail"></param>
 		/// <returns></returns>
@@ -72,6 +76,7 @@ namespace Upflux_WebService.Services.Interfaces
 			string[] deviceUuids,
 			string fileName,
 			byte[] packageData,
+			byte[] signatureData,
 			DateTime startTimeUtc,
 			string userEmail
 		);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/da2894a2-960a-4da5-bf2d-eb2ff8fcc133)
- these endpoints now check for a signature file in the same directory as the package
- if signature file is found send it alongside the package
- if not found throw NotFound error