### PR TITLE
59863 - Create QR machine details page

### DIFF
--- a/upflux-client/src/App.tsx
+++ b/upflux-client/src/App.tsx
@@ -16,6 +16,7 @@ import { CommonDashboard } from './features/commonDashboard/CommonDashboard';
 import store from './features/reduxSubscription/store';
 import SessionTimeout from './features/sessionTimeout/SessionTimeout';
 import '@mantine/charts/styles.css';
+import { MachineDetails } from './features/machineDetails/MachineDetails';
 export const App = () => {
 
   // This function is called when the session times out.
@@ -37,6 +38,7 @@ export const App = () => {
               <Route path="/login" element={<LoginComponent />} />
               <Route path="/admin-login" element={<AdminLogin />} />
               <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/machine-details" element={<MachineDetails />} />
 
               {/* Protected Routes - Wrap with SessionTimeout */}
               <Route

--- a/upflux-client/src/App.tsx
+++ b/upflux-client/src/App.tsx
@@ -17,6 +17,7 @@ import store from './features/reduxSubscription/store';
 import SessionTimeout from './features/sessionTimeout/SessionTimeout';
 import '@mantine/charts/styles.css';
 import { MachineDetails } from './features/machineDetails/MachineDetails';
+import MachineDetailsRoute from './features/machineDetails/MachineDetailsRoute';
 export const App = () => {
 
   // This function is called when the session times out.
@@ -38,7 +39,7 @@ export const App = () => {
               <Route path="/login" element={<LoginComponent />} />
               <Route path="/admin-login" element={<AdminLogin />} />
               <Route path="/forgot-password" element={<ForgotPassword />} />
-              <Route path="/machine-details" element={<MachineDetails />} />
+              <Route path="/machine-details" element={<MachineDetailsRoute />} />
 
               {/* Protected Routes - Wrap with SessionTimeout */}
               <Route

--- a/upflux-client/src/features/footer/Footer.tsx
+++ b/upflux-client/src/features/footer/Footer.tsx
@@ -13,15 +13,6 @@ export const Footer = () => {
         <Text size="sm" className="upflux-copyright">
           Copyright © 2024 UpFlux all rights reserved
         </Text>
-
-        <Group gap="lg" className="footer-links">
-          <Anchor href="/privacy-policy" className="footer-link">
-            Privacy Policy
-          </Anchor>
-          <Anchor href="/terms-conditions" className="footer-link">
-            Terms and Conditions
-          </Anchor>
-        </Group>
       </div>
     </Container>
   );

--- a/upflux-client/src/features/machineDetails/MachineDetails.tsx
+++ b/upflux-client/src/features/machineDetails/MachineDetails.tsx
@@ -15,19 +15,16 @@ import ReactSpeedometer from "react-d3-speedometer";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { RootState } from "../reduxSubscription/store";
-import { IApplications } from "../reduxSubscription/applicationVersions";
 import { getMachineDetails } from "../../api/applicationsRequest";
 
 export const MachineDetails: React.FC = () => {
   const storedMachines = useSelector((root: RootState) => root.machines.messages);
-  const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages);
   const machineMetrics = useSelector((state: RootState) => state.metrics.metrics);
 
   const [modalOpened, setModalOpened] = useState(false);
   const [selectedMachineName, setSelectedMachineName] = useState("");
   const [selectedMachineId, setSelectedMachineId] = useState("");
   const [appVersions, setAppVersions] = useState<{ appName: string; appVersion: string; lastUpdate: string }[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [availableVersions, setAvailableVersions] = useState<string[]>([]);
 
   const location = useLocation();
@@ -58,9 +55,20 @@ export const MachineDetails: React.FC = () => {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const machineId = params.get("machineId");
-    setSelectedMachineName(machineId || "");
-    setSelectedMachineId(machineId || "");
-  }, [location.search]);
+  
+    if (machineId) {
+      setSelectedMachineId(machineId);
+  
+      // Look for machine name from Redux store
+      const matchedMachine = storedMachines[machineId];
+      if (matchedMachine) {
+        setSelectedMachineName(matchedMachine.machineName);
+      } else {
+        setSelectedMachineName("Unknown Machine");
+      }
+    }
+  }, [location.search, storedMachines]);
+  
   
   useEffect(() => {
     if (selectedMachineId) {
@@ -159,7 +167,12 @@ export const MachineDetails: React.FC = () => {
       label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
       size={16}
     >
-      <Text fw={700} style={{ textAlign: "center" }} size="sm">{selectedMachineName}</Text>
+    <Text fw={700} style={{ textAlign: "center", fontSize: "1rem" }} size="lg">
+    {selectedMachineName}
+    </Text>
+    <Text fw={700} style={{ textAlign: "center", fontSize: "1rem" }} size="md">
+        ID: {selectedMachineId}
+    </Text>
        {/* Display Current Version */}
        <Text fw={500} style={{ textAlign: "center" }} size="sm">
         Current Version: {storedMachines[selectedMachineId]?.currentVersion || "N/A"}

--- a/upflux-client/src/features/machineDetails/MachineDetails.tsx
+++ b/upflux-client/src/features/machineDetails/MachineDetails.tsx
@@ -30,8 +30,6 @@ export const MachineDetails: React.FC = () => {
 
   const location = useLocation();
   const isMobile = useMediaQuery("(max-width: 768px)");
-  const speedoWidth = isMobile ? 160 : 250;
-  const speedoHeight = isMobile ? 120 : 150;
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -41,9 +39,51 @@ export const MachineDetails: React.FC = () => {
   }, [location.search, storedMachines]);
 
   const cpuColors = ["#00FF00", "#00FF00", "#00FF00", "#00FF00", "#00FF00", "#00FF00", "#00FF00", "#00FF00", "#33FF00", "#FFFF00", "#FFFF00", "#FF0000", "#FF0000"];
-  const tempColors = [...cpuColors];
-  const memoryColors = [...cpuColors];
-  const diskColors = [...cpuColors];
+  const tempColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000",
+    "#FF0000", // Red 
+  ];
+
+  const memoryColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000", // Red 
+  ];
+
+  const diskColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000",
+    "#FF0000", // Red 
+  ];
 
   const formatUptime = (seconds: number): string => {
     const days = Math.floor(seconds / (24 * 3600));
@@ -74,23 +114,34 @@ export const MachineDetails: React.FC = () => {
   return (
     <Stack className="version-control-content">
       <Box className="content-wrapper">
-        <Box className="machine-id-box">
-          {selectedMachineName ? (
-            <Indicator
-              inline
-              color={storedMachines[selectedMachineId]?.isOnline ? "green" : "red"}
-              label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
-              size={16}
-            >
-              <Text fw={700}>{selectedMachineName}</Text>
-            </Indicator>
-          ) : (
-            <Text color="red" fw={700}>Invalid or Missing Machine ID</Text>
-          )}
-        </Box>
+      <Box
+  className="machine-id-box"
+  style={{
+    display: "flex",
+    justifyContent: "center",
+    width: "100%",
+  }}
+>
+  {selectedMachineName ? (
+    <Indicator
+      inline
+      color={storedMachines[selectedMachineId]?.isOnline ? "green" : "red"}
+      label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
+      size={16}
+    >
+      <Text fw={700}>{selectedMachineName}</Text>
+       {/* Display Current Version */}
+       <Text fw={500} style={{ textAlign: "center" }} size="sm">
+        Current Version: {storedMachines[selectedMachineId]?.currentVersion || "N/A"}
+      </Text>
+    </Indicator>
+  ) : (
+    <Text color="red" fw={700}>Invalid or Missing Machine ID</Text>
+  )}
+</Box>
 
         {/* Metrics Section */}
-        <Box className="metrics-container">
+        <Box className="new-metrics-container">
           <SimpleGrid
             cols={isMobile ? 2 : 4}
           >
@@ -111,8 +162,8 @@ export const MachineDetails: React.FC = () => {
                   }
                   value={metric.value}
                   needleColor="black"
-                  width={speedoWidth}
-                  height={speedoHeight}
+                  width={200}
+                  height={130}
                   ringWidth={30}
                   maxSegmentLabels={4}
                 />

--- a/upflux-client/src/features/machineDetails/MachineDetails.tsx
+++ b/upflux-client/src/features/machineDetails/MachineDetails.tsx
@@ -1,0 +1,264 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Stack,
+  Table,
+  Text,
+  Select,
+  Modal,
+  SimpleGrid,
+  Indicator
+} from "@mantine/core";
+import ReactSpeedometer, { Transition } from "react-d3-speedometer";
+import { useSelector } from "react-redux";
+import { RootState } from "../reduxSubscription/store";
+import { IApplications } from "../reduxSubscription/applicationVersions";
+
+export const MachineDetails: React.FC = () => {
+  //Machine list from redux 
+  const storedMachines = useSelector((root: RootState) => root.machines.messages)
+  const cpuColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000",
+    "#FF0000", // Red 
+  ];
+
+  const tempColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000",
+    "#FF0000", // Red 
+  ];
+
+  const memoryColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000", // Red 
+  ];
+
+  const diskColors = [
+    "#00FF00", // Green
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#00FF00",
+    "#33FF00",
+    "#FFFF00", // Yellow 
+    "#FFFF00",
+    "#FF0000",
+    "#FF0000", // Red 
+  ];
+
+  // State for Modal visibility
+  const [modalOpened, setModalOpened] = useState(false);
+  const applications: Record<string, IApplications> = useSelector((state: RootState) => state.applications.messages)
+  const machineMetrics = useSelector(
+    (state: RootState) => state.metrics.metrics
+  );
+
+  const [selectedMachineName, setSelectedMachineName] = useState("")
+  const [selectedMachineId, setSelectedMachineId] = useState("")
+
+  const findMachineIdByName = (name) => {
+    return Object.entries(storedMachines).find(([, machine]) => machine.machineName === name)?.[0] || "";
+  };
+
+  useEffect(() => {
+    setSelectedMachineId(findMachineIdByName(selectedMachineName))
+  }, [selectedMachineName])
+
+
+  // State for app versions and loading status
+  const [appVersions, setAppVersions] = useState<
+    { appName: string; appVersion: string; lastUpdate: string }[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const formatUptime = (seconds: number): string => {
+    const days = Math.floor(seconds / (24 * 3600));
+    const hours = Math.floor((seconds % (24 * 3600)) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+
+    return `${days}d ${hours}h ${minutes}m`;
+  };
+
+  // Mocked machine metrics data
+  const metrics = [
+    {
+      label: "CPU (%)",
+      value: parseInt(machineMetrics[selectedMachineId]?.metrics.cpuUsage.toFixed()) || 0,
+    },
+    {
+      label: "CPU Temp (°C)",
+      value: parseInt(
+        machineMetrics[selectedMachineId]?.metrics.cpuTemperature.toFixed()
+      ) || 0,
+    },
+    {
+      label: "Memory Usage (%)",
+      value: parseInt(machineMetrics[selectedMachineId]?.metrics.memoryUsage.toFixed()) || 0,
+    },
+    {
+      label: "Disk Usage (%)",
+      value: parseInt(machineMetrics[selectedMachineId]?.metrics.diskUsage.toFixed()) || 0,
+    },
+  ];
+
+  // Determine the color based on the metric value
+  const getColor = (value: number) => {
+    if (value <= 50) return "green";
+    if (value > 50 && value <= 80) return "orange";
+    return "red";
+  };
+
+  return (
+    <Stack className="version-control-content">
+
+      <Box className="content-wrapper">
+        <Box className="machine-id-box">
+          {selectedMachineName && (
+            <Indicator
+              inline
+              color={storedMachines[selectedMachineId]?.isOnline ? "green" : "red"}
+              label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
+              size={16}
+            >
+              <Select
+                data={Object.values(storedMachines).map(m => m.machineName)}
+                value={selectedMachineName}
+                onChange={(value) => setSelectedMachineName(value)}
+                placeholder="Select Machine"
+              />
+            </Indicator>
+          )}
+
+          {!selectedMachineName && (
+            <Select
+              data={Object.values(storedMachines).map(m => m.machineName)}
+              value={selectedMachineName}
+              onChange={(value) => setSelectedMachineName(value)}
+              placeholder="Select Machine"
+            />
+          )}
+        </Box>
+
+        {/* Machine Metrics Section */}
+        <Box className="metrics-container">
+          <SimpleGrid cols={4}>
+            {metrics.map((metric, index) => (
+              <Box key={index} style={{ textAlign: "center" }}>
+                <ReactSpeedometer
+                  key={index}
+                  minValue={0}
+                  maxValue={100}
+                  segments={cpuColors.length}
+                  segmentColors={
+                    index % 4 === 0
+                      ? cpuColors
+                      : index % 4 === 1
+                        ? tempColors
+                        : index % 4 === 2
+                          ? memoryColors
+                          : diskColors
+                  }
+                  value={metric.value}
+                  needleColor="black"
+                  width={250}
+                  height={150}
+                  ringWidth={30}
+                  maxSegmentLabels={4}
+                />
+                <Text className="metrics-labels" size="sm" fw="bold" mt="sm">
+                  {metric.label}
+                </Text>
+              </Box>
+            ))}
+          </SimpleGrid>
+          <center>
+            <h2 style={{ textAlign: "center" }}>
+              System Uptime: {formatUptime(machineMetrics[selectedMachineId]?.metrics.systemUptime || 0)}
+            </h2>
+          </center>
+        </Box>
+
+        {/* Table Section */}
+        <Box>
+          <Table className="version-table" highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>App Name</Table.Th>
+                <Table.Th>Version</Table.Th>
+                <Table.Th>Last Updated</Table.Th>
+                <Table.Th>Updated By</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              <Table.Tr >
+                <Table.Td>{storedMachines[selectedMachineId]?.appName}</Table.Td>
+                <Table.Td>{storedMachines[selectedMachineId]?.currentVersion}</Table.Td>
+                <Table.Td>{storedMachines[selectedMachineId]?.dateAddedOn}</Table.Td>
+                <Table.Td>{storedMachines[selectedMachineId]?.lastUpdatedBy}</Table.Td>
+              </Table.Tr>
+            </Table.Tbody>
+          </Table>
+
+        </Box>
+      </Box>
+
+      {/* Modal for Configure Update */}
+      <Modal
+        opened={modalOpened}
+        onClose={() => setModalOpened(false)}
+        title="Configure Update"
+        centered
+      >
+        <Box>
+          <Text>Select App*</Text>
+          <Select
+            data={appVersions.map((app) => app.appName)}
+            placeholder="Select App"
+          />
+          <Text mt="md">Select App Version*</Text>
+          <Select
+            data={appVersions.map((app) => app.appVersion)}
+            placeholder="Select App Version"
+          />
+          <Button mt="md" fullWidth>
+            Deploy
+          </Button>
+        </Box>
+      </Modal>
+    </Stack>
+  );
+};

--- a/upflux-client/src/features/machineDetails/MachineDetails.tsx
+++ b/upflux-client/src/features/machineDetails/MachineDetails.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mantine/core";
 import ReactSpeedometer, { Transition } from "react-d3-speedometer";
 import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import { RootState } from "../reduxSubscription/store";
 import { IApplications } from "../reduxSubscription/applicationVersions";
 
@@ -94,9 +95,17 @@ export const MachineDetails: React.FC = () => {
     return Object.entries(storedMachines).find(([, machine]) => machine.machineName === name)?.[0] || "";
   };
 
+  const location = useLocation();
+
   useEffect(() => {
-    setSelectedMachineId(findMachineIdByName(selectedMachineName))
-  }, [selectedMachineName])
+    const params = new URLSearchParams(location.search);
+    const machineId = params.get("machineId");
+
+    if (machineId && storedMachines[machineId]) {
+      setSelectedMachineId(machineId);
+      setSelectedMachineName(storedMachines[machineId].machineName);
+    }
+  }, [location.search, storedMachines]);
 
 
   // State for app versions and loading status
@@ -146,32 +155,23 @@ export const MachineDetails: React.FC = () => {
     <Stack className="version-control-content">
 
       <Box className="content-wrapper">
-        <Box className="machine-id-box">
-          {selectedMachineName && (
-            <Indicator
-              inline
-              color={storedMachines[selectedMachineId]?.isOnline ? "green" : "red"}
-              label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
-              size={16}
-            >
-              <Select
-                data={Object.values(storedMachines).map(m => m.machineName)}
-                value={selectedMachineName}
-                onChange={(value) => setSelectedMachineName(value)}
-                placeholder="Select Machine"
-              />
-            </Indicator>
-          )}
+      <Box className="machine-id-box">
+  {selectedMachineName && (
+    <Indicator
+      inline
+      color={storedMachines[selectedMachineId]?.isOnline ? "green" : "red"}
+      label={storedMachines[selectedMachineId]?.isOnline ? "Online" : "Offline"}
+      size={16}
+    >
+      <Text fw={700}>{selectedMachineName}</Text>
+    </Indicator>
+  )}
 
-          {!selectedMachineName && (
-            <Select
-              data={Object.values(storedMachines).map(m => m.machineName)}
-              value={selectedMachineName}
-              onChange={(value) => setSelectedMachineName(value)}
-              placeholder="Select Machine"
-            />
-          )}
-        </Box>
+  {!selectedMachineName && (
+    <Text color="red" fw={700}>Invalid or Missing Machine ID</Text>
+  )}
+</Box>
+
 
         {/* Machine Metrics Section */}
         <Box className="metrics-container">
@@ -210,29 +210,6 @@ export const MachineDetails: React.FC = () => {
               System Uptime: {formatUptime(machineMetrics[selectedMachineId]?.metrics.systemUptime || 0)}
             </h2>
           </center>
-        </Box>
-
-        {/* Table Section */}
-        <Box>
-          <Table className="version-table" highlightOnHover>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>App Name</Table.Th>
-                <Table.Th>Version</Table.Th>
-                <Table.Th>Last Updated</Table.Th>
-                <Table.Th>Updated By</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              <Table.Tr >
-                <Table.Td>{storedMachines[selectedMachineId]?.appName}</Table.Td>
-                <Table.Td>{storedMachines[selectedMachineId]?.currentVersion}</Table.Td>
-                <Table.Td>{storedMachines[selectedMachineId]?.dateAddedOn}</Table.Td>
-                <Table.Td>{storedMachines[selectedMachineId]?.lastUpdatedBy}</Table.Td>
-              </Table.Tr>
-            </Table.Tbody>
-          </Table>
-
         </Box>
       </Box>
 

--- a/upflux-client/src/features/machineDetails/MachineDetailsRoute.tsx
+++ b/upflux-client/src/features/machineDetails/MachineDetailsRoute.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mantine/core';
+import './machineDetails.css';
+import {BlankNavbar} from '../../features/navbar/BlankNavbar';
+import {MachineDetails} from './MachineDetails';
+import { Footer } from '../footer/Footer';
+
+const MachineDetailsRoute: React.FC = () => {
+    return (
+        <>
+            <BlankNavbar />
+            <Box className="details-section">
+            <MachineDetails />
+            </Box>
+            <Footer />
+        </>
+    );
+};
+
+export default MachineDetailsRoute;

--- a/upflux-client/src/features/machineDetails/machineDetails.css
+++ b/upflux-client/src/features/machineDetails/machineDetails.css
@@ -1,0 +1,3 @@
+.metrics-container{
+    margin-left: -10px;
+}

--- a/upflux-client/src/features/machineDetails/machineDetails.css
+++ b/upflux-client/src/features/machineDetails/machineDetails.css
@@ -1,3 +1,4 @@
-.metrics-container{
-    margin-left: -10px;
+.new-metrics-container{
+    margin-top: 20px;
+    margin-left: -15px;
 }

--- a/upflux-client/src/features/machineDetails/machineDetails.css
+++ b/upflux-client/src/features/machineDetails/machineDetails.css
@@ -2,3 +2,12 @@
     margin-top: 20px;
     margin-left: -15px;
 }
+
+.details-section{
+    margin-top: 100px;
+}
+
+.machine-id-box{
+    margin-top: -5px;
+    padding-bottom: 15px;
+}

--- a/upflux-client/src/features/navbar/BlankNavbar.tsx
+++ b/upflux-client/src/features/navbar/BlankNavbar.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from "react";
+import { Container, Image, Menu, Text, Group, Avatar } from "@mantine/core";
+import { Link } from "react-router-dom";
+import logo from "../../assets/logos/logo-light-large.png";
+import "./navbar.css";
+import { useAuth } from "../../common/authProvider/AuthProvider";
+
+export const BlankNavbar: React.FC = () => {
+
+  return (
+    <Container fluid className="navbar">
+      <div className="navbar-logo">
+        {(
+          <>
+            <Image src={logo} alt="Logo" className="logo" />
+          </>
+        )}
+      </div>
+    </Container>
+  );
+};


### PR DESCRIPTION
Created the machine details page which will display for a user when scanning a machine's QR code. This page is read-only and simply displays the current machine live metrics and information.

Screenshot:
![454545](https://github.com/user-attachments/assets/8efcf125-4a0b-40cb-a090-49eb0aa2c8b5)
